### PR TITLE
* Add Calibre-specific meta tags

### DIFF
--- a/chyoa/__init__.py
+++ b/chyoa/__init__.py
@@ -39,8 +39,8 @@ def main(argv=[__file__]):
             print("Usage: %s tree path" % os.path.basename(argv[0]))
             exit(1)
 
-        if debug: print("ChyoaTree(%s)" % path)
         path = argv[2]
+        if debug: print("ChyoaTree(%s)" % path)
         tree = ChyoaTree(path)
         tree.display()
     else:

--- a/chyoa/__main__.py
+++ b/chyoa/__main__.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
+import sys
 
 if __package__ is None and not hasattr(sys, "frozen"):
     # directly call __main__.py
     import os.path
-    path = os.path.realpath(os.path.abspath(__file))
+    path = os.path.realpath(os.path.abspath(__file__))
     sys.path.insert(0, os.path.dirname(os.path.dirname(path)))
 
 import chyoa
-import sys
 
 if __name__ == "__main__":
     chyoa.main(sys.argv)

--- a/chyoa/download.py
+++ b/chyoa/download.py
@@ -1,7 +1,7 @@
 __all__ = ["Downloader"]
 
 from .scraper import Scraper
-from .serial import write_story, write_tar, write_zip
+from .serial import write_story, write_tar, write_zip, write_chapter
 import re
 
 ZIP_FILE_REGEX = re.compile(r".*\.zip", re.IGNORECASE)
@@ -18,7 +18,7 @@ class Downloader(object):
 
         if debug: print("Scraper().scrape(%s)" % url)
         scraper = Scraper()
-        scraper.scrape(url)
+        scraper.scrape(url, self.recursive)
         story = scraper.story
         if debug: print("story: %s" % story)
 

--- a/chyoa/scraper.py
+++ b/chyoa/scraper.py
@@ -21,13 +21,11 @@ class Scraper(object):
         fields = self.parser.get_chapter_fields(url)
         self.visited.add(url)
         self.story = Story(**fields)
-
         print("Story \"%s\":\nRoot \"%s\":\n%s" % (
             self.story.title, self.story.name, get_choice_names(self.story.choices)))
-
-        self._scrape_urls(list(self.story.choices))
-
+        
         if recursive:
+            self._scrape_urls(list(self.story.choices))
             while self.to_visit:
                 self._scrape_urls(self.to_visit)
 

--- a/chyoa/serial.py
+++ b/chyoa/serial.py
@@ -7,6 +7,7 @@ import json
 import os
 import tarfile
 import tempfile
+import urllib.parse
 
 HTML_TEMPLATE = """\
 <!DOCTYPE html>
@@ -15,6 +16,7 @@ HTML_TEMPLATE = """\
 <title>%s</title>
 <meta http-equiv="Content-Type" content="text/html;charset=UTF-8" />
 <meta charset="UTF-8" />
+%s
 </head>
 <body>
 %%s
@@ -24,11 +26,47 @@ HTML_TEMPLATE = """\
 </html>
 """
 
+
+TOC_TEMPLATE = """\
+<!DOCTYPE html>
+<html>
+<head>
+<title>%s</title>
+<meta http-equiv="Content-Type" content="text/html;charset=UTF-8" />
+<meta charset="UTF-8" />
+%s
+</head>
+<body>
+<ul>
+%s
+</ul>
+</body>
+</html>
+"""
+
+
+
+
+
+
+STORY_METADATA_TEMPLATE = """\
+<meta name="author" content="%s" />
+<meta name="tags" content="%s" />
+<meta name="comment" content="%s" />
+<meta name="pubdate" content="%s" />
+<meta name="date of creation" content="%s" />
+<meta name="publisher" content="chyoa.com" />
+<meta name="url" content="url:%s" />
+"""
+
+
 CHAPTER_HEADER_TEMPLATE = """\
 <center>
+%s
 <h1>%s</h1>
-<h3>%s</h3>
-by <a href="%s">%s</a>
+%s
+%s
+<h4>Chapter %s by <a href="https://chyoa.com/user/%s">%s</a></h4>
 </center>
 """
 
@@ -52,26 +90,34 @@ def generate_chapter_header(chapter):
         name = chapter.title
     else:
         name = chapter.name
+    prev_question = ""
+    if chapter.prev_question is not None:
+        prev_question = "<h2>%s</h2>" % chapter.prev_question
+    subtitle = ""
+    if hasattr(chapter, "subtitle"):
+        subtitle = "<h2>%s</h2>" % chapter.subtitle
 
     if hasattr(chapter, "description"):
-        description = chapter.description
+        description = "<h3>%s</h3>" % chapter.description
     else:
         description = ""
-
+        
     return format_html(CHAPTER_HEADER_TEMPLATE,
-            name, description, chapter.author, chapter.author)
+            prev_question, name, subtitle, description, chapter.chapter_number, chapter.author.strip(), chapter.author.strip())
 
 def generate_chapter_links(chapter, chapter_pool):
     links = []
 
     for choice_id, choice_url in chapter.choices:
+        (_, _, choice_path) = choice_url.rpartition('/')
+        choice_path = choice_path.replace('%22', '_')
         if choice_id in chapter_pool.keys():
             name = chapter_pool[choice_id].name
         else:
-            name = choice_url
-
-        links.append("<li><a href=\"%s\">%s</a>"
-                % (html.escape(choice_url), html.escape(name)))
+            (choice_name, _, _) = choice_path.rpartition('.')
+            name = urllib.parse.unquote(choice_name.replace('-','%20'))
+        links.append("<li><a href=\"./%s.html\">%s</a>"
+            % (choice_path, html.escape(name)))
 
     return format_html(CHAPTER_LINKS_TEMPLATE, chapter.question, "\n".join(links))
 
@@ -82,9 +128,16 @@ def write_story(story, dest_dir):
         "author": story.author,
         "root": story.id,
         "url": story.url,
+        "tags": story.tags,
+        "file_path": story.file_path,
+        "created": story.created,
+        "modified": story.modified,
+        "chapter_number": story.chapter_number,
+        "subtitle": story.subtitle,
     }
 
     story_path = os.path.join(dest_dir, "meta.json")
+    index_path = os.path.join(dest_dir, "index.html")
 
     if not os.path.exists(dest_dir):
         os.mkdir(dest_dir)
@@ -92,9 +145,33 @@ def write_story(story, dest_dir):
     with codecs.open(story_path, "w", "utf-8") as fh:
         json.dump(data, fh)
 
+    with codecs.open(index_path, "w", "utf-8") as fh:
+        fh.write(generate_toc(story))
+
+
     write_chapter(story, dest_dir, story.chapters)
     for chapter in story.chapters.values():
         write_chapter(chapter, dest_dir)
+
+def generate_toc(story):
+    # Calibre's html import by default is kinda screwy and won't import
+    #  more than five levels of html files by default and it's difficult 
+    #  to override. This obviously won't work with chyoa stories that 
+    #  are dozens or hundreds of chapters deep, so just write out a TOC
+    #  file with links to all the chapters.
+    retval = TOC_TEMPLATE % \
+        (story.title, get_metadata(story), '\n'.join(get_all_links(story)))
+    return retval
+
+def get_all_links(story):
+    retval = [get_link(story)]
+    for chapter in story.chapters.values():
+        retval.append(get_link(chapter))
+    return retval
+
+def get_link(chapter):
+    return '<li><a href="./%s.html">%s</a></li>' % (urllib.parse.quote(chapter.file_path),chapter.name)
+
 
 def write_chapter(chapter, dest_dir, chapter_pool={}):
     metadata = {
@@ -102,6 +179,11 @@ def write_chapter(chapter, dest_dir, chapter_pool={}):
         "author": chapter.author,
         "id": chapter.id,
         "question": chapter.question,
+        "tags" : chapter.tags,
+        "file_path": chapter.file_path,
+        "url": chapter.url,
+        "prev_question": chapter.prev_question,
+        "chapter_number": chapter.chapter_number,
     }
 
     if not os.path.exists(dest_dir):
@@ -109,21 +191,42 @@ def write_chapter(chapter, dest_dir, chapter_pool={}):
 
     choice_ids = []
     for choice in chapter.choices:
-        choice_ids.append(choice[0])
+        (_, _, choice_name) = choice[1].rpartition('/')
+        choice_name = choice_name.replace('%22', '_')
+        choice_ids.append(choice_name)
 
     metadata["choices"] = choice_ids
+    name = chapter.name
+    if hasattr(chapter, "title"):
+        name = chapter.title
+        metadata["title"] = chapter.title
+        metadata["description"] = chapter.description
+        # apply meta tags so calibre will generate meaningful metadata
 
-    html_data = format_html(HTML_TEMPLATE, chapter.name, chapter.text)
+    meta_tags = get_metadata(chapter)
+
+    html_data = format_html(HTML_TEMPLATE, name, meta_tags, chapter.text)
     html_data = html_data % (generate_chapter_header(chapter), generate_chapter_links(chapter, chapter_pool))
-
-    metadata_path = os.path.join(dest_dir, "%s.json" % chapter.id)
-    html_path = os.path.join(dest_dir, "%s.html" % chapter.id)
+    if "<li>" not in html_data:
+        # the empty ul tag breaks calibre's parsing, so remove 'em
+        html_data = html_data.replace("<ul>\n\n</ul>", "")
+    metadata_path = os.path.join(dest_dir, "%s.json" % chapter.file_path)
+    html_path = os.path.join(dest_dir, "%s.html" % chapter.file_path)
 
     with codecs.open(metadata_path, "w", "utf-8") as fh:
         json.dump(metadata, fh)
 
     with codecs.open(html_path, "w", "utf-8") as fh:
         fh.write(html_data)
+
+def get_metadata(chapter):
+    description = ''
+    if hasattr(chapter, "description"):
+        description = chapter.description
+    meta_tags = STORY_METADATA_TEMPLATE % \
+        (chapter.author, ','.join(chapter.tags), description, chapter.modified, chapter.created, chapter.url)
+    meta_tags = meta_tags.replace("%", "%%")
+    return meta_tags
 
 def write_tar(story, dest_file, compression="", is_story=True):
     temp_dir = tempfile.TemporaryDirectory()

--- a/chyoa/story.py
+++ b/chyoa/story.py
@@ -1,20 +1,30 @@
 __all__ = ["Chapter", "Story"]
 
 from .util import abridge
+import urllib.parse
 
 class Chapter(object):
-    def __init__(self, url, name, description, id, author, text, question, choices):
-        self.url = url
-        self.name = name.replace('%', '%%')
-        self.id = id
-        self.author = author.replace('%', '%%')
-        self.text = text.replace('%', '%%')
-        self.question = question.replace('%', '%%')
-        self.choices = choices # set( (id, chapter_url) )
+    def __init__(self, **kwargs):
+        #url, name, description, id, author, text, question, choices, tags, created_time, modified_time):
+        self.url = kwargs["url"]
+        self.name = kwargs["name"].replace('%', '%%')
+        self.id = kwargs["id"]
+        self.author = kwargs["author"].replace('%', '%%')
+        self.text = kwargs["text"].replace('%', '%%')
+        self.question = kwargs["question"].replace('%', '%%')
+        self.choices = kwargs["choices"] # set( (id, chapter_url) )
+        (_,_,path) = kwargs["url"].rpartition('/')
+        # strip quotes out of the filesystem name because windows will choke on them
+        self.file_path = urllib.parse.unquote(path).replace('"', '_')
+        self.modified = kwargs["modified_time"]
+        self.created = kwargs["created_time"]
+        self.tags = kwargs["tags"]
+        self.prev_question = kwargs["prev_question"]
+        self.chapter_number = kwargs["chapter_number"]
 
     def __repr__(self):
         return """Chapter(url=%r, name=%r, author=%r, text=%r, question=%r, choices=%s\n)""" % (
-                self.url, self.name, self.author, abridge(self.text), self.question, self.choices)
+            self.url, self.name, self.author, abridge(self.text), self.question, self.choices)
 
 class Story(Chapter):
     def __init__(self, **kwargs):
@@ -24,8 +34,8 @@ class Story(Chapter):
         self.description = kwargs["description"]
         self.chapters = {}
         # chapters: { id: chapter_object }
+        self.subtitle = kwargs["subtitle"]
 
     def __repr__(self):
         return """Story(title=%r, description=%r, root=%s\n)""" % (
-                self.title, self.description, Chapter.__repr__(self))
-
+            self.title, self.description, Chapter.__repr__(self))

--- a/chyoa/tree.py
+++ b/chyoa/tree.py
@@ -2,6 +2,8 @@ __all__ = ["ChyoaTree", "TreeCharset", "Tree", "STANDARD_TREE_CHARSET", "ASCII_T
 
 import json
 import os
+import urllib.parse
+
 
 class TreeCharset(object):
     def __init__(self, trunk, intersection, branch, corner):
@@ -37,7 +39,7 @@ class Tree(object):
 
             child = child_list[i]
             print("%s%s%s %s" %
-                    (self.get_indent(level, charset), corner, charset.branch, child))
+                (self.get_indent(level, charset), corner, charset.branch, child))
 
             if children[child]:
                 self.display_subtree(children[child], level + [notlast], charset)
@@ -61,7 +63,7 @@ class ChyoaTree(Tree):
         with open("meta.json", "r") as fh:
             meta = json.load(fh)
 
-        name, tree = self.build_dict(meta["root"])
+        name, tree = self.build_dict(meta["file_path"])
         Tree.__init__(self, name, tree)
         os.chdir(prev_dir)
 
@@ -69,7 +71,7 @@ class ChyoaTree(Tree):
     def build_dict(id):
         tree = {}
 
-        with open("%d.json" % id, "r") as fh:
+        with open("%s.json" % urllib.parse.unquote(id), "r") as fh:
             chapter = json.load(fh)
 
         name = chapter["name"]


### PR DESCRIPTION
* Save files to their chapter names instead of chapter numbers
* Link files locally
* Grab tags, story subtitle, chapter numbers, prompts, creation / modification times, cover url
* Don't scrape recursively in download-only mode
* Fix some syntax errors in seldom-used codepaths
* Display description, subtitle, chapter number, prompts in generated html
* Generate a table of contents index.html for better importing into calibre